### PR TITLE
Set map.showTerritoryNames=false on GoT map.

### DIFF
--- a/map/map.properties
+++ b/map/map.properties
@@ -18,3 +18,4 @@ map.showCapitolMarkers=false
 map.width=6377
 map.height=7305
 map.scrollWrapX=false
+map.showTerritoryNames=false


### PR DESCRIPTION
Set map.showTerritoryNames=false on GoT map.

The map image already includes territory names as part of the image. Having them shown twice is messy.